### PR TITLE
Fix missing cherry fence gate sound

### DIFF
--- a/resource_pack/sounds/sound_definitions.json
+++ b/resource_pack/sounds/sound_definitions.json
@@ -4046,8 +4046,7 @@
          "sounds" : [
             "sounds/block/bamboo_wood_trapdoor/toggle1",
             "sounds/block/bamboo_wood_trapdoor/toggle2",
-            "sounds/block/bamboo_wood_trapdoor/toggle3",
-            "sounds/block/bamboo_wood_trapdoor/toggle4"
+            "sounds/block/bamboo_wood_trapdoor/toggle3"
          ]
       },
       "close.cherry_wood_door" : {
@@ -4057,8 +4056,7 @@
          "sounds" : [
             "sounds/block/cherry_wood_door/toggle1",
             "sounds/block/cherry_wood_door/toggle2",
-            "sounds/block/cherry_wood_door/toggle3",
-            "sounds/block/cherry_wood_door/toggle4"
+            "sounds/block/cherry_wood_door/toggle3"
          ]
       },
       "close.cherry_wood_fence_gate" : {


### PR DESCRIPTION
The toggle4 sound for Cherry Wood Fence Gate's does not exist, resulting in the sound of opening/closing the gate sometimes not playing anything. Resolves [MCPE-168021](https://bugs.mojang.com/browse/MCPE-168021)